### PR TITLE
Minor Tweaks

### DIFF
--- a/app/routes/post_routes.js
+++ b/app/routes/post_routes.js
@@ -29,7 +29,7 @@ router.get('/posts', requiresToken, (req, res, next) => {
         postObj.posts.push({
           _id: post._id,
           content: post.content,
-          owner: post.owner.fullName,
+          owner: post.owner,
           createdAt: post.createdAt
         })
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "express-api-template",
-  "version": "0.0.1",
+  "name": "hyruliantimes-api",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "express-api-template",
-  "version": "0.0.1",
+  "name": "hyruliantimes-api",
+  "version": "1.1.0",
   "description": "",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
- Updated version and package name
- Changed how the owner of the post gets returned. Now it returns the whole user object instead of just their name

There was a bug where two people with the same name but different accounts would see the edit/delete buttons on posts that weren't theirs. To fix this, I changed the returned data to return the whole object and not just their name so the client can check the emails as the emails are unique.